### PR TITLE
hamster-windows-server: fix compat code in develpment mode

### DIFF
--- a/src/hamster-windows-service.py
+++ b/src/hamster-windows-service.py
@@ -41,11 +41,13 @@ class WindowServer(dbus.service.Object):
 
     def _open_window(self, name):
         if hamster.installed:
-            subprocess.run("hamster {} &".format(name),
-                           shell=True)
+            base_cmd = "hamster"
         else:
-            subprocess.run("python3 {}/hamster-cli.py {} &".format(
-                os.path.dirname(__file__), name), shell=True)
+            # both scripts are at the same place in the source tree
+            cwd = os.path.dirname(__file__)
+            base_cmd = "python3 {}/hamster-cli.py".format(cwd)
+        cmd = "{} {} &".format(base_cmd, name)
+        subprocess.run(cmd, shell=True)
 
     @dbus.service.method("org.gnome.Hamster.WindowServer")
     def edit(self, id=0):

--- a/src/hamster-windows-service.py
+++ b/src/hamster-windows-service.py
@@ -49,7 +49,7 @@ class WindowServer(dbus.service.Object):
         cmd = "{} {} &".format(base_cmd, name)
         subprocess.run(cmd, shell=True)
 
-    @dbus.service.method("org.gnome.Hamster.WindowServer")
+    @dbus.service.method("org.gnome.Hamster.WindowServer", in_signature='i')
     def edit(self, id=0):
         """Edit fact, given its id (int) in the database.
 

--- a/src/hamster-windows-service.py
+++ b/src/hamster-windows-service.py
@@ -19,7 +19,8 @@ if "org.gnome.Hamster.WindowServer" in dbus.SessionBus().list_names():
 
 
 # Legacy server. Still used by the shell-extension.
-# new code could access the org.gnome.Hamster.GUI actions directly
+# New code _could_ access the org.gnome.Hamster.GUI actions directly,
+# although the exact action names/data are subject to change.
 # http://lazka.github.io/pgi-docs/Gio-2.0/classes/Application.html#Gio.Application
 # > The actions are also exported on the session bus,
 #   and GIO provides the Gio.DBusActionGroup wrapper

--- a/src/hamster-windows-service.py
+++ b/src/hamster-windows-service.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 # nicked off hamster-service
 
+import os.path
 import dbus
 import dbus.service
 import subprocess
+import hamster
 
 from dbus.mainloop.glib import DBusGMainLoop
 from gi.repository import GLib as glib
@@ -38,8 +40,12 @@ class WindowServer(dbus.service.Object):
         self.mainloop.quit()
 
     def _open_window(self, name):
-        subprocess.run("hamster {} &".format(name),
-                       shell=True)
+        if hamster.installed:
+            subprocess.run("hamster {} &".format(name),
+                           shell=True)
+        else:
+            subprocess.run("python3 {}/hamster-cli.py {} &".format(
+                os.path.dirname(__file__), name), shell=True)
 
     @dbus.service.method("org.gnome.Hamster.WindowServer")
     def edit(self, id=0):


### PR DESCRIPTION
This code doesn't run in development mode if the installed version doesn't have the "edit" action yet.
Fix it.